### PR TITLE
Fixed unit tests to not block on testing preventing running

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 
 [dev-dependencies]
 axum = "0.7.5"
+http-body-util = "0.1.1"
 reqwest = "0.12.4"
 tokio = "1.37.0"
+tower = "0.4.13"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ use axum::{
     Router,
 };
 use clap::Parser;
-use std::io::Result;
 
 #[derive(Parser)]
 pub struct Cli {
@@ -36,14 +35,9 @@ pub async fn health_check() -> impl IntoResponse {
     (StatusCode::OK, "")
 }
 
-pub async fn run(cli: Cli) -> Result<()> {
-    let addr = cli.addr;
-    let port = cli.port.to_string();
-    // Naive way to create a binded address
-    let bind_addr = format!("{}:{}", addr, port);
-
+pub fn app() -> Router {
     // Define single routes for now
-    let app = Router::new()
+    Router::new()
         .route(
             "/",
             get(|| async {
@@ -51,9 +45,5 @@ pub async fn run(cli: Cli) -> Result<()> {
             }),
         )
         .route("/:name", get(greet))
-        .route("/health_check", get(health_check));
-
-    // Run app using hyper while listening onto the configured port
-    let listener = tokio::net::TcpListener::bind(bind_addr).await.unwrap();
-    axum::serve(listener, app).await
+        .route("/health_check", get(health_check))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,11 +30,18 @@
 //! * Allow authors to send emails to subscribers
 
 use clap::Parser;
-use std::io::Result;
-use zero2prod_axum::{run, Cli};
+use zero2prod_axum::{app, Cli};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
     let cli = Cli::parse();
-    run(cli).await
+
+    let addr = cli.addr;
+    let port = cli.port.to_string();
+    // Naive way to create a binded address
+    let bind_addr = format!("{}:{}", addr, port);
+
+    // Run app using hyper while listening onto the configured port
+    let listener = tokio::net::TcpListener::bind(bind_addr).await.unwrap();
+    axum::serve(listener, app()).await.unwrap();
 }

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,25 +1,55 @@
 //! health_check.rs
 
-use std::io::Result;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use reqwest::Client;
+use std::net::SocketAddr;
+use tower::ServiceExt;
 
 const ADDR: &str = "127.0.0.1";
-const PORT: u16 = 9000;
+/// Bind to port 0 which causes the OS to hunt for an available port.
+const PORT: u16 = 0;
 
+/// Oneshot test
+///
+/// This requires tower to provide `.oneshot` as wel as http_body_util
+/// to be able to `.collect()` the body.
+#[tokio::test]
+async fn health_check_oneshot() {
+    let app = zero2prod_axum::app();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health_check")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"");
+}
+
+/// Client test
+///
+/// Tests proper http client requests.
 #[tokio::test]
 async fn health_check_works() {
-    // Arrange
-    spawn_app().await.expect("Failed to spaw our app.");
+    let addr = spawn_app().await;
 
-    // Use reqwest to do HTTP requests
-    let client = reqwest::Client::new();
-
-    // Act
-    let bind_addr = format!("{}:{}", ADDR, PORT);
+    let client = Client::new();
     let resp = client
-        .get(format!("http://{}/health_check", bind_addr))
+        .get(format!("http://{addr}/health_check"))
         .send()
         .await
-        .expect("Failed to execut request.");
+        .expect("Failed to execute request.");
 
     assert!(resp.status().is_success());
     assert_eq!(resp.content_length(), Some(0));
@@ -30,10 +60,19 @@ async fn health_check_works() {
 /// Spawn's the app, which can be replaced with decoupled backend, for
 /// example, Django. This allows us to change the backend implementation
 /// but still use the testing pipline here as needed.
-async fn spawn_app() -> Result<()> {
+async fn spawn_app() -> SocketAddr {
     let cli = zero2prod_axum::Cli {
         addr: ADDR.to_string(),
         port: PORT,
     };
-    zero2prod_axum::run(cli).await
+    let bind_addr = format!("{}:{}", cli.addr.to_string(), cli.port);
+
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let _ = tokio::spawn(async move {
+        axum::serve(listener, zero2prod_axum::app()).await.unwrap();
+    });
+
+    addr
 }


### PR DESCRIPTION
Unit tests were blocking `test` on,
```
cargo watch -x check -x test -x run
```
so the server that is active was the one generated by the testing libraries. This would cause the system to build and run the actual server in debug or release mode. By using `tokio::spawn` or `tower::ServiceExt` to use `.oneshot` for `axum::Router` solves this issue.
